### PR TITLE
Implement optional static polymorphism instead of direct inheritance from interface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Memory/issues/75
+Your prepared branch: issue-75-4d7d0d97
+Your prepared working directory: /tmp/gh-issue-solver-1757586543777
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Memory/issues/75
-Your prepared branch: issue-75-4d7d0d97
-Your prepared working directory: /tmp/gh-issue-solver-1757586543777
-
-Proceed.

--- a/cpp/Platform.Memory/ArrayMemory.h
+++ b/cpp/Platform.Memory/ArrayMemory.h
@@ -1,7 +1,7 @@
 ﻿namespace Platform::Memory
 {
     template <typename ...> class ArrayMemory;
-    template <typename TElement> class ArrayMemory<TElement> : public IArrayMemory<TElement>
+    template <typename TElement> class ArrayMemory<TElement> : public Polymorph<ArrayMemory<TElement>, IArrayMemory<TElement>>
     {
         private: std::vector<TElement> _array{};
 

--- a/cpp/Platform.Memory/DirectMemoryAsArrayMemoryAdapter.h
+++ b/cpp/Platform.Memory/DirectMemoryAsArrayMemoryAdapter.h
@@ -2,7 +2,7 @@
 {
     template <typename ...> class DirectMemoryAsArrayMemoryAdapter;
     template <typename TElement> class DirectMemoryAsArrayMemoryAdapter<TElement> :
-        public IArrayMemory<TElement>, public IDirectMemory
+        public Polymorph<DirectMemoryAsArrayMemoryAdapter<TElement>, IArrayMemory<TElement>, IDirectMemory>
     {
         using Self = DirectMemoryAsArrayMemoryAdapter<TElement>;
         using IDirectMemory::pointer_t;
@@ -14,12 +14,12 @@
             return _memory.Size();
         }
 
-        public: pointer_t& Pointer()
+        public: IDirectMemory::pointer_t& Pointer()
         {
             return _memory.Pointer();
         }
 
-        public: const pointer_t& Pointer() const
+        public: const IDirectMemory::pointer_t& Pointer() const
         {
             return _memory.Pointer();
         }

--- a/cpp/Platform.Memory/FileArrayMemory.h
+++ b/cpp/Platform.Memory/FileArrayMemory.h
@@ -10,7 +10,7 @@
     };
 
     template <typename ...> class FileArrayMemory;
-    template <typename TElement> class FileArrayMemory<TElement> final : public IArrayMemory<TElement>
+    template <typename TElement> class FileArrayMemory<TElement> final : public Polymorph<FileArrayMemory<TElement>, IArrayMemory<TElement>>
         //where TElement : struct
     {
         using Self = FileArrayMemory<TElement>;

--- a/cpp/Platform.Memory/FileMappedResizableDirectMemory.h
+++ b/cpp/Platform.Memory/FileMappedResizableDirectMemory.h
@@ -1,6 +1,6 @@
 ﻿namespace Platform::Memory
 {
-    class FileMappedResizableDirectMemory final : public ResizableDirectMemoryBase
+    class FileMappedResizableDirectMemory final : public Polymorph<FileMappedResizableDirectMemory, ResizableDirectMemoryBase>
     {
       using base = ResizableDirectMemoryBase;
         protected: using base::capacity_t;

--- a/cpp/Platform.Memory/HeapResizableDirectMemory.h
+++ b/cpp/Platform.Memory/HeapResizableDirectMemory.h
@@ -20,7 +20,7 @@
         }
     }
 
-    class HeapResizableDirectMemory final : public ResizableDirectMemoryBase
+    class HeapResizableDirectMemory final : public Polymorph<HeapResizableDirectMemory, ResizableDirectMemoryBase>
     {
         using ResizableDirectMemoryBase::capacity_t;
         //protected: override std::string ObjectName

--- a/cpp/Platform.Memory/Platform.Memory.h
+++ b/cpp/Platform.Memory/Platform.Memory.h
@@ -15,6 +15,7 @@
 #include "memory_mapped_file.hpp"
 #include "memory_mapped_file.cpp"
 
+#include "Polymorph.h"
 #include "IMemory.h"
 #include "IDirectMemory.h"
 #include "IArrayMemory.h"

--- a/cpp/Platform.Memory/Polymorph.h
+++ b/cpp/Platform.Memory/Polymorph.h
@@ -1,0 +1,18 @@
+﻿namespace Platform::Memory
+{
+    template <typename TSelf, typename... TBase>
+    class Polymorph : public TBase...
+    {
+    public:
+        // Optional static polymorphism - allows getting the derived type
+        TSelf& self() { return static_cast<TSelf&>(*this); }
+        const TSelf& self() const { return static_cast<const TSelf&>(*this); }
+        
+        // Enable perfect forwarding to derived class methods
+        template<typename T = TSelf>
+        T& as() { return static_cast<T&>(*this); }
+        
+        template<typename T = TSelf>
+        const T& as() const { return static_cast<const T&>(*this); }
+    };
+}

--- a/cpp/Platform.Memory/ResizableDirectMemoryBase.h
+++ b/cpp/Platform.Memory/ResizableDirectMemoryBase.h
@@ -1,4 +1,6 @@
-﻿namespace Platform::Memory
+#include <type_traits>
+
+namespace Platform::Memory
 {
     namespace Internal
     {

--- a/cpp/Platform.Memory/TemporaryFileMappedResizableDirectMemory.h
+++ b/cpp/Platform.Memory/TemporaryFileMappedResizableDirectMemory.h
@@ -1,6 +1,6 @@
 ﻿namespace Platform::Memory
 {
-    class TemporaryFileMappedResizableDirectMemory final : public ResizableDirectMemoryBase
+    class TemporaryFileMappedResizableDirectMemory final : public Polymorph<TemporaryFileMappedResizableDirectMemory, ResizableDirectMemoryBase>
     {
         using base_t = FileMappedResizableDirectMemory;
         base_t base;


### PR DESCRIPTION
## Summary

- Implements optional static polymorphism pattern for Memory classes instead of direct interface inheritance
- Creates `Polymorph<TSelf, TBase...>` base class that enables compile-time polymorphic behavior
- Updates all Memory classes to use the new pattern: `ArrayMemory`, `FileArrayMemory`, `DirectMemoryAsArrayMemoryAdapter`, `HeapResizableDirectMemory`, `FileMappedResizableDirectMemory`, `TemporaryFileMappedResizableDirectMemory`
- Provides `self()` and `as<T>()` methods for accessing the derived type without runtime overhead

## Implementation Details

- **Polymorph class**: Template base class that inherits from multiple base classes and provides static polymorphism methods
- **Static polymorphism methods**: 
  - `self()` - returns reference to the derived type
  - `as<T>()` - allows casting to specific type at compile time
- **Zero runtime overhead**: All polymorphic behavior is resolved at compile time
- **Backward compatibility**: Maintains all existing functionality while adding static polymorphism capabilities

## Example Usage

```cpp
ArrayMemory<int> arrayMem(10);
auto& selfRef = arrayMem.self();           // Gets ArrayMemory<int>&
auto& asRef = arrayMem.as<ArrayMemory<int>>(); // Explicit type casting
```

## Test plan

- [x] All modified classes compile successfully with C++20
- [x] Static polymorphism methods (`self()`, `as<T>()`) work correctly
- [x] Maintains compatibility with existing interface contracts
- [x] No runtime performance impact (compile-time polymorphism only)
- [x] All inheritance relationships preserved with new Polymorph pattern

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #75