### PR TITLE
Remove comments for private members

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Memory/issues/67
-Your prepared branch: issue-67-9ed2497b
-Your prepared working directory: /tmp/gh-issue-solver-1757732422353
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Memory/issues/67
+Your prepared branch: issue-67-9ed2497b
+Your prepared working directory: /tmp/gh-issue-solver-1757732422353
+
+Proceed.

--- a/csharp/Platform.Memory/FileMappedResizableDirectMemory.cs
+++ b/csharp/Platform.Memory/FileMappedResizableDirectMemory.cs
@@ -19,10 +19,6 @@ namespace Platform.Memory
         private MemoryMappedFile _file;
         private MemoryMappedViewAccessor _accessor;
 
-        /// <summary>
-        /// <para>Gets path to memory mapped file.</para>
-        /// <para>Получает путь к отображенному в памяти файлу.</para>
-        /// </summary>
         protected readonly string Path;
 
         #endregion


### PR DESCRIPTION
## Summary
Removed XML documentation comments from private/protected members as requested in issue #67.

### Changes Made
- Removed XML documentation comments from the `protected readonly string Path` field in `FileMappedResizableDirectMemory.cs`

### Test Plan
- [x] Verified the project compiles successfully
- [x] No compilation errors introduced
- [x] Only warnings remain (which were pre-existing)

Fixes #67

🤖 Generated with [Claude Code](https://claude.ai/code)