### PR TITLE
Fix broken workflow badge link in README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Memory/issues/49
-Your prepared branch: issue-49-3d607293
-Your prepared working directory: /tmp/gh-issue-solver-1757780278370
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Memory/issues/49
+Your prepared branch: issue-49-3d607293
+Your prepared working directory: /tmp/gh-issue-solver-1757780278370
+
+Proceed.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![NuGet Version and Downloads count](https://img.shields.io/nuget/v/Platform.Memory?label=nuget&style=flat)](https://www.nuget.org/packages/Platform.Memory)
-[![Actions Status](https://github.com/linksplatform/Memory/workflows/CD/badge.svg)](https://github.com/linksplatform/Memory/actions?workflow=CD)
+[![Actions Status](https://github.com/linksplatform/Memory/actions/workflows/csharp.yml/badge.svg)](https://github.com/linksplatform/Memory/actions/workflows/csharp.yml)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/b50408b8bf1443c6900c4253449d9568)](https://app.codacy.com/gh/linksplatform/Memory?utm_source=github.com&utm_medium=referral&utm_content=linksplatform/Memory&utm_campaign=Badge_Grade_Settings)
 [![CodeFactor](https://www.codefactor.io/repository/github/linksplatform/memory/badge)](https://www.codefactor.io/repository/github/linksplatform/memory)
 


### PR DESCRIPTION
## Summary

* Fixed broken workflow badge URL that was returning 404
* Updated from non-existent 'CD' workflow to correct 'csharp' workflow
* The csharp workflow includes continuous deployment functionality (NuGet publishing, releases)

## Test plan

- [x] Verified all links in README.md are working (HTTP 200 responses)
- [x] Confirmed new workflow badge displays correctly
- [x] Verified workflow actions page is accessible

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #49