### PR TITLE
Add non-resizable memory implementations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Memory/issues/48
+Your prepared branch: issue-48-f35f4a76
+Your prepared working directory: /tmp/gh-issue-solver-1757780537385
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Memory/issues/48
-Your prepared branch: issue-48-f35f4a76
-Your prepared working directory: /tmp/gh-issue-solver-1757780537385
-
-Proceed.

--- a/csharp/Platform.Memory.Tests/FileMappedFixedDirectMemoryTests.cs
+++ b/csharp/Platform.Memory.Tests/FileMappedFixedDirectMemoryTests.cs
@@ -1,0 +1,124 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace Platform.Memory.Tests
+{
+    public unsafe class FileMappedFixedDirectMemoryTests : IDisposable
+    {
+        private readonly string _testFilePath;
+        
+        public FileMappedFixedDirectMemoryTests()
+        {
+            _testFilePath = Path.GetTempFileName();
+        }
+        
+        public void Dispose()
+        {
+            if (File.Exists(_testFilePath))
+            {
+                File.Delete(_testFilePath);
+            }
+        }
+        
+        [Fact]
+        public void ConstructorWithCapacityTest()
+        {
+            const long capacity = 8192;
+            using var fileMemory = new FileMappedFixedDirectMemory(_testFilePath, capacity);
+            
+            Assert.Equal(capacity, fileMemory.Capacity);
+            Assert.Equal(capacity, fileMemory.Size);
+            Assert.NotEqual(IntPtr.Zero, fileMemory.Pointer);
+            Assert.True(File.Exists(_testFilePath));
+            Assert.Equal(capacity, new FileInfo(_testFilePath).Length);
+        }
+        
+        [Fact]
+        public void DefaultCapacityConstructorTest()
+        {
+            using var fileMemory = new FileMappedFixedDirectMemory(_testFilePath);
+            
+            Assert.Equal(FileMappedFixedDirectMemory.MinimumCapacity, fileMemory.Capacity);
+            Assert.Equal(FileMappedFixedDirectMemory.MinimumCapacity, fileMemory.Size);
+            Assert.NotEqual(IntPtr.Zero, fileMemory.Pointer);
+            Assert.True(File.Exists(_testFilePath));
+            Assert.Equal(FileMappedFixedDirectMemory.MinimumCapacity, new FileInfo(_testFilePath).Length);
+        }
+        
+        [Fact]
+        public void MinimumCapacityEnforcementTest()
+        {
+            const long smallCapacity = 1;
+            using var fileMemory = new FileMappedFixedDirectMemory(_testFilePath, smallCapacity);
+            
+            Assert.Equal(FileMappedFixedDirectMemory.MinimumCapacity, fileMemory.Capacity);
+            Assert.Equal(FileMappedFixedDirectMemory.MinimumCapacity, fileMemory.Size);
+        }
+        
+        [Fact]
+        public void WriteAndReadTest()
+        {
+            const long capacity = 8192;
+            using var fileMemory = new FileMappedFixedDirectMemory(_testFilePath, capacity);
+            
+            var pointer = (byte*)fileMemory.Pointer;
+            const byte testValue = 42;
+            
+            // Write test value at different positions
+            pointer[0] = testValue;
+            pointer[capacity / 2] = testValue;
+            pointer[capacity - 1] = testValue;
+            
+            // Verify values
+            Assert.Equal(testValue, pointer[0]);
+            Assert.Equal(testValue, pointer[capacity / 2]);
+            Assert.Equal(testValue, pointer[capacity - 1]);
+        }
+        
+        [Fact]
+        public void PersistenceTest()
+        {
+            const long capacity = 8192;
+            const byte testValue = 123;
+            
+            // Write data in first instance
+            using (var fileMemory1 = new FileMappedFixedDirectMemory(_testFilePath, capacity))
+            {
+                var pointer1 = (byte*)fileMemory1.Pointer;
+                pointer1[100] = testValue;
+                pointer1[capacity - 100] = testValue;
+            }
+            
+            // Read data in second instance
+            using (var fileMemory2 = new FileMappedFixedDirectMemory(_testFilePath, capacity))
+            {
+                var pointer2 = (byte*)fileMemory2.Pointer;
+                Assert.Equal(testValue, pointer2[100]);
+                Assert.Equal(testValue, pointer2[capacity - 100]);
+            }
+        }
+        
+        [Fact]
+        public void EmptyPathArgumentTest()
+        {
+            Assert.Throws<ArgumentException>(() => new FileMappedFixedDirectMemory(""));
+            Assert.Throws<ArgumentException>(() => new FileMappedFixedDirectMemory("   "));
+        }
+        
+        [Fact]
+        public void DisposeTest()
+        {
+            var fileMemory = new FileMappedFixedDirectMemory(_testFilePath, 8192);
+            var pointer = fileMemory.Pointer;
+            
+            Assert.NotEqual(IntPtr.Zero, pointer);
+            
+            fileMemory.Dispose();
+            
+            Assert.Throws<ObjectDisposedException>(() => fileMemory.Pointer);
+            Assert.Throws<ObjectDisposedException>(() => fileMemory.Capacity);
+            Assert.Throws<ObjectDisposedException>(() => fileMemory.Size);
+        }
+    }
+}

--- a/csharp/Platform.Memory.Tests/HeapFixedDirectMemoryTests.cs
+++ b/csharp/Platform.Memory.Tests/HeapFixedDirectMemoryTests.cs
@@ -1,0 +1,87 @@
+using System;
+using Xunit;
+
+namespace Platform.Memory.Tests
+{
+    public unsafe class HeapFixedDirectMemoryTests
+    {
+        [Fact]
+        public void ConstructorWithCapacityTest()
+        {
+            const long capacity = 8192;
+            using var heapMemory = new HeapFixedDirectMemory(capacity);
+            
+            Assert.Equal(capacity, heapMemory.Capacity);
+            Assert.Equal(capacity, heapMemory.Size);
+            Assert.NotEqual(IntPtr.Zero, heapMemory.Pointer);
+        }
+        
+        [Fact]
+        public void DefaultConstructorTest()
+        {
+            using var heapMemory = new HeapFixedDirectMemory();
+            
+            Assert.Equal(FixedDirectMemoryBase.MinimumCapacity, heapMemory.Capacity);
+            Assert.Equal(FixedDirectMemoryBase.MinimumCapacity, heapMemory.Size);
+            Assert.NotEqual(IntPtr.Zero, heapMemory.Pointer);
+        }
+        
+        [Fact]
+        public void MinimumCapacityEnforcementTest()
+        {
+            const long smallCapacity = 1;
+            using var heapMemory = new HeapFixedDirectMemory(smallCapacity);
+            
+            Assert.Equal(FixedDirectMemoryBase.MinimumCapacity, heapMemory.Capacity);
+            Assert.Equal(FixedDirectMemoryBase.MinimumCapacity, heapMemory.Size);
+        }
+        
+        [Fact]
+        public void MemoryIsZeroInitializedTest()
+        {
+            const long capacity = 8192;
+            using var heapMemory = new HeapFixedDirectMemory(capacity);
+            
+            var pointer = (byte*)heapMemory.Pointer;
+            for (long i = 0; i < capacity; i++)
+            {
+                Assert.Equal(0, pointer[i]);
+            }
+        }
+        
+        [Fact]
+        public void WriteAndReadTest()
+        {
+            const long capacity = 8192;
+            using var heapMemory = new HeapFixedDirectMemory(capacity);
+            
+            var pointer = (byte*)heapMemory.Pointer;
+            const byte testValue = 42;
+            
+            // Write test value at different positions
+            pointer[0] = testValue;
+            pointer[capacity / 2] = testValue;
+            pointer[capacity - 1] = testValue;
+            
+            // Verify values
+            Assert.Equal(testValue, pointer[0]);
+            Assert.Equal(testValue, pointer[capacity / 2]);
+            Assert.Equal(testValue, pointer[capacity - 1]);
+        }
+        
+        [Fact]
+        public void DisposeTest()
+        {
+            var heapMemory = new HeapFixedDirectMemory(8192);
+            var pointer = heapMemory.Pointer;
+            
+            Assert.NotEqual(IntPtr.Zero, pointer);
+            
+            heapMemory.Dispose();
+            
+            Assert.Throws<ObjectDisposedException>(() => heapMemory.Pointer);
+            Assert.Throws<ObjectDisposedException>(() => heapMemory.Capacity);
+            Assert.Throws<ObjectDisposedException>(() => heapMemory.Size);
+        }
+    }
+}

--- a/csharp/Platform.Memory/FileMappedFixedDirectMemory.cs
+++ b/csharp/Platform.Memory/FileMappedFixedDirectMemory.cs
@@ -1,0 +1,187 @@
+using System;
+using System.IO;
+using System.IO.MemoryMappedFiles;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Platform.Disposables;
+using Platform.Exceptions;
+using Platform.Collections;
+
+namespace Platform.Memory
+{
+    /// <summary>
+    /// <para>Represents a fixed-size memory block stored as a file on disk.</para>
+    /// <para>Представляет блок памяти фиксированного размера, хранящийся в виде файла на диске.</para>
+    /// </summary>
+    public unsafe class FileMappedFixedDirectMemory : DisposableBase, IFixedDirectMemory
+    {
+        #region Constants
+
+        /// <summary>
+        /// <para>Gets minimum capacity in bytes.</para>
+        /// <para>Возвращает минимальную емкость в байтах.</para>
+        /// </summary>
+        public static readonly long MinimumCapacity = Environment.SystemPageSize;
+
+        #endregion
+
+        #region Fields
+        private MemoryMappedFile _file;
+        private MemoryMappedViewAccessor _accessor;
+        private IntPtr _pointer;
+        private readonly long _capacity;
+
+        /// <summary>
+        /// <para>Gets path to memory mapped file.</para>
+        /// <para>Получает путь к отображенному в памяти файлу.</para>
+        /// </summary>
+        protected readonly string Path;
+
+        #endregion
+
+        #region Properties
+
+        /// <inheritdoc/>
+        /// <include file='bin\Release\netstandard2.0\Platform.Memory.xml' path='doc/members/member[@name="P:Platform.Memory.IMemory.Size"]/*'/>
+        /// <exception cref="ObjectDisposedException"><para>The memory block is disposed.</para><para>Блок памяти уже высвобожден.</para></exception>
+        public long Size
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                Ensure.Always.NotDisposed(this);
+                return _capacity;
+            }
+        }
+
+        /// <inheritdoc/>
+        /// <include file='bin\Release\netstandard2.0\Platform.Memory.xml' path='doc/members/member[@name="P:Platform.Memory.IFixedDirectMemory.Capacity"]/*'/>
+        /// <exception cref="ObjectDisposedException"><para>The memory block is disposed.</para><para>Блок памяти уже высвобожден.</para></exception>
+        public long Capacity
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                Ensure.Always.NotDisposed(this);
+                return _capacity;
+            }
+        }
+
+        /// <inheritdoc/>
+        /// <include file='bin\Release\netstandard2.0\Platform.Memory.xml' path='doc/members/member[@name="P:Platform.Memory.IDirectMemory.Pointer"]/*'/>
+        /// <exception cref="ObjectDisposedException"><para>The memory block is disposed.</para><para>Блок памяти уже высвобожден.</para></exception>
+        public IntPtr Pointer
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                Ensure.Always.NotDisposed(this);
+                return _pointer;
+            }
+        }
+
+        #endregion
+
+        #region DisposableBase Properties
+
+        /// <inheritdoc/>
+        protected override bool AllowMultipleDisposeCalls
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => true;
+        }
+
+        /// <inheritdoc/>
+        protected override string ObjectName
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => $"Fixed file stored memory block at '{Path}' path.";
+        }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// <para>Initializes a new instance of the <see cref="FileMappedFixedDirectMemory"/> class.</para>
+        /// <para>Инициализирует новый экземпляр класса <see cref="FileMappedFixedDirectMemory"/>.</para>
+        /// </summary>
+        /// <param name="path"><para>An path to file.</para><para>Путь к файлу.</para></param>
+        /// <param name="capacity"><para>Fixed capacity in bytes.</para><para>Фиксированный размер в байтах.</para></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public FileMappedFixedDirectMemory(string path, long capacity)
+        {
+            Ensure.Always.ArgumentNotEmptyAndNotWhiteSpace(path, nameof(path));
+            Path = path;
+            
+            _capacity = capacity < MinimumCapacity ? MinimumCapacity : capacity;
+            AllocateMemory(_capacity);
+        }
+
+        /// <summary>
+        /// <para>Initializes a new instance of the <see cref="FileMappedFixedDirectMemory"/> class.</para>
+        /// <para>Инициализирует новый экземпляр класса <see cref="FileMappedFixedDirectMemory"/>.</para>
+        /// </summary>
+        /// <param name="path"><para>An path to file.</para><para>Путь к файлу.</para></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public FileMappedFixedDirectMemory(string path) : this(path, MinimumCapacity) { }
+
+        #endregion
+
+        #region Methods
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void AllocateMemory(long capacity)
+        {
+            SetFileSize(Path, capacity);
+            _file = MemoryMappedFile.CreateFromFile(Path, FileMode.Open, mapName: null, capacity, MemoryMappedFileAccess.ReadWrite);
+            _accessor = _file.CreateViewAccessor();
+            byte* pointer = null;
+            _accessor.SafeMemoryMappedViewHandle.AcquirePointer(ref pointer);
+            _pointer = new IntPtr(pointer);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void SetFileSize(string path, long size)
+        {
+            using var fileStream = new FileStream(path, FileMode.OpenOrCreate, FileAccess.Write);
+            fileStream.SetLength(size);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool UnmapFile(IntPtr pointer)
+        {
+            if (pointer == IntPtr.Zero)
+            {
+                return false;
+            }
+            if (_accessor != null)
+            {
+                _accessor.SafeMemoryMappedViewHandle.ReleasePointer();
+                Disposable.TryDisposeAndResetToDefault(ref _accessor);
+            }
+            Disposable.TryDisposeAndResetToDefault(ref _file);
+            return true;
+        }
+
+        #endregion
+
+        #region DisposableBase Methods
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected override void Dispose(bool manual, bool wasDisposed)
+        {
+            if (!wasDisposed)
+            {
+                var pointer = Interlocked.Exchange(ref _pointer, IntPtr.Zero);
+                if (pointer != IntPtr.Zero)
+                {
+                    UnmapFile(pointer);
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/csharp/Platform.Memory/FixedDirectMemoryBase.cs
+++ b/csharp/Platform.Memory/FixedDirectMemoryBase.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Threading;
+using System.Runtime.CompilerServices;
+using Platform.Exceptions;
+using Platform.Disposables;
+
+namespace Platform.Memory
+{
+    /// <summary>
+    /// <para>Provides a base implementation for the fixed-size memory block with direct access (via unmanaged pointers).</para>
+    /// <para>Предоставляет базовую реализацию для блока памяти фиксированного размера с прямым доступом (через неуправляемые указатели).</para>
+    /// </summary>
+    public abstract class FixedDirectMemoryBase : DisposableBase, IFixedDirectMemory
+    {
+        #region Constants
+
+        /// <summary>
+        /// <para>Gets minimum capacity in bytes.</para>
+        /// <para>Возвращает минимальную емкость в байтах.</para>
+        /// </summary>
+        public static readonly long MinimumCapacity = Environment.SystemPageSize;
+
+        #endregion
+
+        #region Fields
+        private IntPtr _pointer;
+        private readonly long _capacity;
+
+        #endregion
+
+        #region Properties
+
+        /// <inheritdoc/>
+        /// <include file='bin\Release\netstandard2.0\Platform.Memory.xml' path='doc/members/member[@name="P:Platform.Memory.IMemory.Size"]/*'/>
+        /// <exception cref="ObjectDisposedException"><para>The memory block is disposed.</para><para>Блок памяти уже высвобожден.</para></exception>
+        public long Size
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                Ensure.Always.NotDisposed(this);
+                return _capacity;
+            }
+        }
+
+        /// <inheritdoc/>
+        /// <include file='bin\Release\netstandard2.0\Platform.Memory.xml' path='doc/members/member[@name="P:Platform.Memory.IFixedDirectMemory.Capacity"]/*'/>
+        /// <exception cref="ObjectDisposedException"><para>The memory block is disposed.</para><para>Блок памяти уже высвобожден.</para></exception>
+        public long Capacity
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                Ensure.Always.NotDisposed(this);
+                return _capacity;
+            }
+        }
+
+        /// <inheritdoc/>
+        /// <include file='bin\Release\netstandard2.0\Platform.Memory.xml' path='doc/members/member[@name="P:Platform.Memory.IDirectMemory.Pointer"]/*'/>
+        /// <exception cref="ObjectDisposedException"><para>The memory block is disposed.</para><para>Блок памяти уже высвобожден.</para></exception>
+        public IntPtr Pointer
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                Ensure.Always.NotDisposed(this);
+                return _pointer;
+            }
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            protected set
+            {
+                Ensure.Always.NotDisposed(this);
+                _pointer = value;
+            }
+        }
+
+        #endregion
+
+        #region DisposableBase Properties
+
+        /// <inheritdoc/>
+        protected override bool AllowMultipleDisposeCalls
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => true;
+        }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// <para>Initializes a new instance of the <see cref="FixedDirectMemoryBase"/> class.</para>
+        /// <para>Инициализирует новый экземпляр класса <see cref="FixedDirectMemoryBase"/>.</para>
+        /// </summary>
+        /// <param name="capacity"><para>The capacity in bytes.</para><para>Размер в байтах.</para></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected FixedDirectMemoryBase(long capacity)
+        {
+            if (capacity < MinimumCapacity)
+            {
+                capacity = MinimumCapacity;
+            }
+            _capacity = capacity;
+            AllocateMemory(capacity);
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// <para>Allocates the memory with the specified capacity.</para>
+        /// <para>Выделяет память с указанной емкостью.</para>
+        /// </summary>
+        /// <param name="capacity"><para>The capacity of the memory block in bytes.</para><para>Емкость блока памяти в байтах.</para></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected abstract void AllocateMemory(long capacity);
+
+        /// <summary>
+        /// <para>Executed when it is time to dispose <see cref="Pointer"/>.</para>
+        /// <para>Выполняется, когда пришло время высвободить <see cref="Pointer"/>.</para>
+        /// </summary>
+        /// <param name="pointer"><para>The pointer to a memory block.</para><para>Указатель на блок памяти.</para></param>
+        /// <param name="capacity"><para>The capacity of the memory block in bytes.</para><para>Емкость блока памяти в байтах.</para></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected abstract void DisposePointer(IntPtr pointer, long capacity);
+
+        #endregion
+
+        #region DisposableBase Methods
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected override void Dispose(bool manual, bool wasDisposed)
+        {
+            if (!wasDisposed)
+            {
+                var pointer = Interlocked.Exchange(ref _pointer, IntPtr.Zero);
+                if (pointer != IntPtr.Zero)
+                {
+                    DisposePointer(pointer, _capacity);
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/csharp/Platform.Memory/HeapFixedDirectMemory.cs
+++ b/csharp/Platform.Memory/HeapFixedDirectMemory.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Platform.Unsafe;
+
+namespace Platform.Memory
+{
+    /// <summary>
+    /// <para>Represents a fixed-size memory block allocated in Heap.</para>
+    /// <para>Представляет блок памяти фиксированного размера, выделенный в "куче".</para>
+    /// </summary>
+    public unsafe class HeapFixedDirectMemory : FixedDirectMemoryBase
+    {
+        #region DisposableBase Properties
+
+        /// <inheritdoc/>
+        protected override string ObjectName
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => $"Fixed heap stored memory block at {Pointer} address.";
+        }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// <para>Initializes a new instance of the <see cref="HeapFixedDirectMemory"/> class.</para>
+        /// <para>Инициализирует новый экземпляр класса <see cref="HeapFixedDirectMemory"/>.</para>
+        /// </summary>
+        /// <param name="capacity"><para>Fixed capacity in bytes.</para><para>Фиксированный размер в байтах.</para></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public HeapFixedDirectMemory(long capacity) : base(capacity) { }
+
+        /// <summary>
+        /// <para>Initializes a new instance of the <see cref="HeapFixedDirectMemory"/> class.</para>
+        /// <para>Инициализирует новый экземпляр класса <see cref="HeapFixedDirectMemory"/>.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public HeapFixedDirectMemory() : this(MinimumCapacity) { }
+
+        #endregion
+
+        #region FixedDirectMemoryBase Methods
+
+        /// <inheritdoc/>
+        /// <include file='bin\Release\netstandard2.0\Platform.Memory.xml' path='doc/members/member[@name="M:Platform.Memory.FixedDirectMemoryBase.AllocateMemory(System.Int64)"]/*'/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected override void AllocateMemory(long capacity)
+        {
+            Pointer = Marshal.AllocHGlobal(new IntPtr(capacity));
+            MemoryBlock.Zero((void*)Pointer, capacity);
+        }
+
+        /// <inheritdoc/>
+        /// <include file='bin\Release\netstandard2.0\Platform.Memory.xml' path='doc/members/member[@name="M:Platform.Memory.FixedDirectMemoryBase.DisposePointer(System.IntPtr,System.Int64)"]/*'/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected override void DisposePointer(IntPtr pointer, long capacity) => Marshal.FreeHGlobal(pointer);
+
+        #endregion
+    }
+}

--- a/csharp/Platform.Memory/IFixedDirectMemory.cs
+++ b/csharp/Platform.Memory/IFixedDirectMemory.cs
@@ -1,0 +1,21 @@
+using System.Runtime.CompilerServices;
+
+namespace Platform.Memory
+{
+    /// <summary>
+    /// <para>Represents a fixed-size memory block interface with direct access (via unmanaged pointers).</para>
+    /// <para>Представляет интерфейс блока памяти фиксированного размера с прямым доступом (через неуправляемые указатели).</para>
+    /// </summary>
+    public interface IFixedDirectMemory : IDirectMemory
+    {
+        /// <summary>
+        /// <para>Gets the capacity in bytes of this fixed memory block.</para>
+        /// <para>Возвращает размер блока памяти фиксированного размера в байтах.</para>
+        /// </summary>
+        long Capacity
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get;
+        }
+    }
+}

--- a/csharp/Platform.Memory/Platform.Memory.csproj
+++ b/csharp/Platform.Memory/Platform.Memory.csproj
@@ -10,7 +10,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Platform.Memory</AssemblyName>
     <PackageId>Platform.Memory</PackageId>
-    <PackageTags>LinksPlatform;Memory;ArrayMemory;DirectMemoryAsArrayMemoryAdapter;FileArrayMemory;FileMappedResizableDirectMemory;HeapResizableDirectMemory;IArrayMemory;IDirectMemory;IMemory;IResizableDirectMemory;ResizableDirectMemoryBase;TemporaryFileMappedResizableDirectMemory;MemoryMappedFiles</PackageTags>
+    <PackageTags>LinksPlatform;Memory;ArrayMemory;DirectMemoryAsArrayMemoryAdapter;FileArrayMemory;FileMappedResizableDirectMemory;HeapResizableDirectMemory;IArrayMemory;IDirectMemory;IMemory;IResizableDirectMemory;ResizableDirectMemoryBase;TemporaryFileMappedResizableDirectMemory;IFixedDirectMemory;FixedDirectMemoryBase;HeapFixedDirectMemory;FileMappedFixedDirectMemory;MemoryMappedFiles</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/linksplatform/Documentation/18469f4d033ee9a5b7b84caab9c585acab2ac519/doc/Avatar-rainbow-icon-64x64.png</PackageIconUrl>
     <PackageProjectUrl>https://linksplatform.github.io/Memory</PackageProjectUrl>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>


### PR DESCRIPTION
## Summary

This PR adds non-resizable (fixed-size) memory implementations to complement the existing resizable memory implementations. These are particularly useful for scenarios where you want to allocate all available resources at once (e.g., all RAM or a whole drive) and avoid time wasted on reallocations.

### New Components Added:

- **`IFixedDirectMemory`** - Interface for fixed-size direct memory access that extends `IDirectMemory`
- **`FixedDirectMemoryBase`** - Abstract base class providing common functionality for fixed memory implementations
- **`HeapFixedDirectMemory`** - Fixed-size memory allocation using unmanaged heap memory
- **`FileMappedFixedDirectMemory`** - Fixed-size memory allocation using memory-mapped files
- **Comprehensive unit tests** - Full test coverage for all new implementations

### Key Features:

- **Performance optimized** - No resize overhead since size is fixed at allocation
- **Resource allocation** - Ideal for allocating all available RAM or storage at once
- **Consistent API** - Follows the same patterns as existing resizable memory implementations
- **Memory safety** - Proper disposal and error handling
- **Cross-platform** - Works on all platforms supported by .NET

### Implementation Details:

- All implementations properly handle minimum capacity enforcement
- Memory is zero-initialized for heap allocations
- File-mapped memory supports persistence across application restarts
- Proper disposal prevents memory leaks
- Thread-safe disposal using atomic operations

### Test Coverage:

- Constructor validation and capacity enforcement
- Memory allocation and deallocation
- Read/write operations
- Persistence testing for file-mapped memory
- Disposal and error condition testing

Resolves #48

🤖 Generated with [Claude Code](https://claude.ai/code)