### PR TITLE
Fix DocFX indexer comments inheritance by removing problematic include tags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Memory/issues/16
-Your prepared branch: issue-16-f79a2ea7
-Your prepared working directory: /tmp/gh-issue-solver-1757839362825
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Memory/issues/16
+Your prepared branch: issue-16-f79a2ea7
+Your prepared working directory: /tmp/gh-issue-solver-1757839362825
+
+Proceed.

--- a/csharp/Platform.Memory/ArrayMemory.cs
+++ b/csharp/Platform.Memory/ArrayMemory.cs
@@ -17,7 +17,6 @@ namespace Platform.Memory
         #region Properties
 
         /// <inheritdoc/>
-        /// <include file='bin\Release\netstandard2.0\Platform.Memory.xml' path='doc/members/member[@name="P:Platform.Memory.IMemory.Size"]/*'/>
         public long Size
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -25,7 +24,6 @@ namespace Platform.Memory
         }
 
         /// <inheritdoc/>
-        /// <include file='bin\Release\netstandard2.0\Platform.Memory.xml' path='doc/members/member[@name="P:Platform.Memory.IArrayMemory`1.Item(System.Int64)"]/*'/>
         public TElement this[long index]
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/csharp/Platform.Memory/DirectMemoryAsArrayMemoryAdapter.cs
+++ b/csharp/Platform.Memory/DirectMemoryAsArrayMemoryAdapter.cs
@@ -22,7 +22,6 @@ namespace Platform.Memory
         #region Properties
 
         /// <inheritdoc/>
-        /// <include file='bin\Release\netstandard2.0\Platform.Memory.xml' path='doc/members/member[@name="P:Platform.Memory.IMemory.Size"]/*'/>
         public long Size
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -30,7 +29,6 @@ namespace Platform.Memory
         }
 
         /// <inheritdoc/>
-        /// <include file='bin\Release\netstandard2.0\Platform.Memory.xml' path='doc/members/member[@name="P:Platform.Memory.IDirectMemory.Pointer"]/*'/>
         public IntPtr Pointer
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -38,7 +36,6 @@ namespace Platform.Memory
         }
 
         /// <inheritdoc/>
-        /// <include file='bin\Release\netstandard2.0\Platform.Memory.xml' path='doc/members/member[@name="P:Platform.Memory.IArrayMemory`1.Item(System.Int64)"]/*'/>
         public TElement this[long index]
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/csharp/Platform.Memory/FileArrayMemory.cs
+++ b/csharp/Platform.Memory/FileArrayMemory.cs
@@ -22,7 +22,6 @@ namespace Platform.Memory
         #region Properties
 
         /// <inheritdoc/>
-        /// <include file='bin\Release\netstandard2.0\Platform.Memory.xml' path='doc/members/member[@name="P:Platform.Memory.IMemory.Size"]/*'/>
         public long Size
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -30,7 +29,6 @@ namespace Platform.Memory
         }
 
         /// <inheritdoc/>
-        /// <include file='bin\Release\netstandard2.0\Platform.Memory.xml' path='doc/members/member[@name="P:Platform.Memory.IArrayMemory`1.Item(System.Int64)"]/*'/>
         public TElement this[long index]
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/csharp/Platform.Memory/FileMappedResizableDirectMemory.cs
+++ b/csharp/Platform.Memory/FileMappedResizableDirectMemory.cs
@@ -113,7 +113,6 @@ namespace Platform.Memory
         #region ResizableDirectMemoryBase Methods
 
         /// <inheritdoc/>
-        /// <include file='bin\Release\netstandard2.0\Platform.Memory.xml' path='doc/members/member[@name="M:Platform.Memory.ResizableDirectMemoryBase.OnReservedCapacityChanged(System.Int64,System.Int64)"]/*'/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected override void OnReservedCapacityChanged(long oldReservedCapacity, long newReservedCapacity)
         {
@@ -123,7 +122,6 @@ namespace Platform.Memory
         }
 
         /// <inheritdoc/>
-        /// <include file='bin\Release\netstandard2.0\Platform.Memory.xml' path='doc/members/member[@name="M:Platform.Memory.ResizableDirectMemoryBase.DisposePointer(System.IntPtr,System.Int64)"]/*'/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected override void DisposePointer(IntPtr pointer, long usedCapacity)
         {

--- a/csharp/Platform.Memory/HeapResizableDirectMemory.cs
+++ b/csharp/Platform.Memory/HeapResizableDirectMemory.cs
@@ -52,12 +52,10 @@ namespace Platform.Memory
         #region ResizableDirectMemoryBase Methods
 
         /// <inheritdoc/>
-        /// <include file='bin\Release\netstandard2.0\Platform.Memory.xml' path='doc/members/member[@name="M:Platform.Memory.ResizableDirectMemoryBase.DisposePointer(System.IntPtr,System.Int64)"]/*'/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected override void DisposePointer(IntPtr pointer, long usedCapacity) => Marshal.FreeHGlobal(pointer);
 
         /// <inheritdoc/>
-        /// <include file='bin\Release\netstandard2.0\Platform.Memory.xml' path='doc/members/member[@name="M:Platform.Memory.ResizableDirectMemoryBase.OnReservedCapacityChanged(System.Int64,System.Int64)"]/*'/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected override void OnReservedCapacityChanged(long oldReservedCapacity, long newReservedCapacity)
         {

--- a/csharp/Platform.Memory/ResizableDirectMemoryBase.cs
+++ b/csharp/Platform.Memory/ResizableDirectMemoryBase.cs
@@ -33,7 +33,6 @@ namespace Platform.Memory
         #region Properties
 
         /// <inheritdoc/>
-        /// <include file='bin\Release\netstandard2.0\Platform.Memory.xml' path='doc/members/member[@name="P:Platform.Memory.IMemory.Size"]/*'/>
         /// <exception cref="ObjectDisposedException"><para>The memory block is disposed.</para><para>Блок памяти уже высвобожден.</para></exception>
         public long Size
         {
@@ -46,7 +45,6 @@ namespace Platform.Memory
         }
 
         /// <inheritdoc/>
-        /// <include file='bin\Release\netstandard2.0\Platform.Memory.xml' path='doc/members/member[@name="P:Platform.Memory.IDirectMemory.Pointer"]/*'/>
         /// <exception cref="ObjectDisposedException"><para>The memory block is disposed.</para><para>Блок памяти уже высвобожден.</para></exception>
         public IntPtr Pointer
         {
@@ -65,7 +63,6 @@ namespace Platform.Memory
         }
 
         /// <inheritdoc/>
-        /// <include file='bin\Release\netstandard2.0\Platform.Memory.xml' path='doc/members/member[@name="P:Platform.Memory.IResizableDirectMemory.ReservedCapacity"]/*'/>
         /// <exception cref="ObjectDisposedException"><para>The memory block is disposed.</para><para>Блок памяти уже высвобожден.</para></exception>
         /// <exception cref="ArgumentOutOfRangeException"><para>Attempted to set the reserved capacity to a value that is less than the used capacity.</para><para>Была выполнена попытка установить зарезервированную емкость на значение, которое меньше используемой емкости.</para></exception>
         public long ReservedCapacity
@@ -90,7 +87,6 @@ namespace Platform.Memory
         }
 
         /// <inheritdoc/>
-        /// <include file='bin\Release\netstandard2.0\Platform.Memory.xml' path='doc/members/member[@name="P:Platform.Memory.IResizableDirectMemory.UsedCapacity"]/*'/>
         /// <exception cref="ObjectDisposedException"><para>The memory block is disposed.</para><para>Блок памяти уже высвобожден.</para></exception>
         /// <exception cref="ArgumentOutOfRangeException"><para>Attempted to set the used capacity to a value that is greater than the reserved capacity or less than zero.</para><para>Была выполнена попытка установить используемую емкость на значение, которое больше, чем зарезервированная емкость или меньше нуля.</para></exception>
         public long UsedCapacity


### PR DESCRIPTION
## Summary
- Fixed DocFX indexer comments inheritance issue by removing problematic XML `<include>` tags
- Replaced all `<include>` references to external XML files with proper `<inheritdoc/>` tags
- DocFX does not properly support XML `<include>` tags for documentation inheritance as mentioned in [dotnet/docfx#2328](https://github.com/dotnet/docfx/issues/2328)

## Changes Made
Fixed documentation in the following files by removing problematic `<include>` tags:

### Indexer Documentation
- **DirectMemoryAsArrayMemoryAdapter.cs**: Fixed indexer, Size, and Pointer properties
- **ArrayMemory.cs**: Fixed indexer and Size property
- **FileArrayMemory.cs**: Fixed indexer and Size property

### Property Documentation  
- **ResizableDirectMemoryBase.cs**: Fixed Size, Pointer, ReservedCapacity, and UsedCapacity properties

### Method Documentation
- **FileMappedResizableDirectMemory.cs**: Fixed OnReservedCapacityChanged and DisposePointer methods
- **HeapResizableDirectMemory.cs**: Fixed OnReservedCapacityChanged and DisposePointer methods

## Solution Approach
The issue was caused by the combination of `/// <inheritdoc/>` tags with `/// <include file='...'>` tags. DocFX handles standard `<inheritdoc/>` tags properly but fails to process the external XML file references from `<include>` tags. 

By removing the `<include>` tags and relying solely on `<inheritdoc/>`, the documentation inheritance now works correctly as the base interfaces (like `IArrayMemory<TElement>`) already contain proper XML documentation.

## Test Results
- ✅ Build passes with no errors
- ✅ All existing tests continue to pass
- ✅ Documentation generation should now work properly for indexers

Resolves #16

🤖 Generated with [Claude Code](https://claude.ai/code)