### PR TITLE
Convert TODO comments to GitHub issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Memory/issues/15
-Your prepared branch: issue-15-fd5e5f4a
-Your prepared working directory: /tmp/gh-issue-solver-1757839966212
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Memory/issues/15
+Your prepared branch: issue-15-fd5e5f4a
+Your prepared working directory: /tmp/gh-issue-solver-1757839966212
+
+Proceed.

--- a/cpp/Platform.Memory/FileMappedResizableDirectMemory.h
+++ b/cpp/Platform.Memory/FileMappedResizableDirectMemory.h
@@ -32,7 +32,6 @@
             }
             Path = path;
             auto size = std::filesystem::file_size(Path);
-            // TODO: cringe
             ReservedCapacity(size > minimumReservedCapacity ? ((size / minimumReservedCapacity) + 1) * minimumReservedCapacity : minimumReservedCapacity);
             UsedCapacity(size);
         }
@@ -63,7 +62,6 @@
             Pointer() = nullptr;
         }
 
-        // TODO: maybe use rvalue friend function
         public: void Close()
         {
 

--- a/cpp/Platform.Memory/IArrayMemory.h
+++ b/cpp/Platform.Memory/IArrayMemory.h
@@ -6,7 +6,6 @@
     public:
         //virtual TElement& operator[](std::size_t index) {}
 
-        // TODO: impl const
         //virtual const TElement& operator[](std::size_t index) const {}
     };
 }

--- a/cpp/Platform.Memory/ResizableDirectMemoryBase.h
+++ b/cpp/Platform.Memory/ResizableDirectMemoryBase.h
@@ -75,7 +75,6 @@
 
             if (value != _usedCapacity)
             {
-                // TODO: Use modernize Ranges version
                 Ensure::Always::ArgumentInRange(value, Range(0, _reservedCapacity));
                 _usedCapacity = value;
             }


### PR DESCRIPTION
## Summary
Converted all TODO comments in the C++ codebase to proper GitHub issues for better tracking and resolution:

- **Issue #87**: Improve capacity calculation in FileMappedResizableDirectMemory constructor
- **Issue #88**: Consider using rvalue friend function in FileMappedResizableDirectMemory::Close()  
- **Issue #89**: Implement const operator[] in IArrayMemory interface
- **Issue #90**: Modernize Ranges usage in ResizableDirectMemoryBase

## Changes Made
- Removed 4 TODO comments from the following files:
  - `cpp/Platform.Memory/FileMappedResizableDirectMemory.h` (2 comments)
  - `cpp/Platform.Memory/IArrayMemory.h` (1 comment) 
  - `cpp/Platform.Memory/ResizableDirectMemoryBase.h` (1 comment)

## Test plan
- [x] Verified all TODO comments have been removed from C++ code
- [x] Created corresponding GitHub issues with detailed descriptions
- [x] Code compiles without changes to functionality

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #15